### PR TITLE
Changed default allocation & filtering strategy

### DIFF
--- a/.chloggen/change-default-strategies.yaml
+++ b/.chloggen/change-default-strategies.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. operator, target allocator, github action)
+component: target allocator
+
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Change default allocation and filtering strategy
+
+# One or more tracking issues related to the change
+issues: [2477]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/cmd/otel-allocator/config/config.go
+++ b/cmd/otel-allocator/config/config.go
@@ -61,7 +61,7 @@ func (c Config) GetAllocationStrategy() string {
 	if c.AllocationStrategy != nil {
 		return *c.AllocationStrategy
 	}
-	return "least-weighted"
+	return "consistent-hashing"
 }
 
 func (c Config) GetTargetsFilterStrategy() string {

--- a/cmd/otel-allocator/config/config.go
+++ b/cmd/otel-allocator/config/config.go
@@ -68,7 +68,7 @@ func (c Config) GetTargetsFilterStrategy() string {
 	if c.FilterStrategy != nil {
 		return *c.FilterStrategy
 	}
-	return ""
+	return "relabel-config"
 }
 
 func LoadFromFile(file string, target *Config) error {


### PR DESCRIPTION
**Description:**
As discussed in the linked issue:
- default value for allocation strategy is changed from `least-weighted` to `consistent-hashing`
- default value for filtering strategy is changed from `none` to `relabel-config`

**Link to tracking Issue:**
[2477](https://github.com/open-telemetry/opentelemetry-operator/issues/2477)

**Testing:**
None required.

**Documentation:**
None required.
